### PR TITLE
Mark failing check in red on the console

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,8 +24,8 @@ pyspelling --config $SPELLCHECK_CONFIG_FILE
 
 EXITCODE=$?
 
-test $EXITCODE -gt 1 && echo "Spelling check action failed, please check diagnostics";
+test $EXITCODE -gt 1 && echo "\033[91Spelling check action failed, please check diagnostics\033[39m";
 
-test $EXITCODE -eq 1 && echo "Files in repository contain spelling errors";
+test $EXITCODE -eq 1 && echo "\033[91mFiles in repository contain spelling errors\033[39m";
 
 exit $EXITCODE


### PR DESCRIPTION
For github actions, it might be proper to allow easy detection if the spell check failed and what went wrong